### PR TITLE
changed financial summary to use events

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -29,6 +29,7 @@ functions:
   CommitteeSync:
     handler: src/CommitteSync.committeSync
     timeout: 30
+    reservedConcurrency: 2
     environment:
       API_KEY: ${self:custom.${self:provider.stage}.API_KEY}
       LOG_LEVEL: ${self:custom.${self:provider.stage}.LOG_LEVEL}
@@ -57,7 +58,8 @@ functions:
 
   FinancialSummaryLoader:
     handler: src/FinancialSummaryLoader.lambdaHandler
-    timeout: 15
+    reservedConcurrency: 2
+    timeout: 60
     environment:
       API_KEY: ${self:custom.${self:provider.stage}.API_KEY}
       LOG_LEVEL: ${self:custom.${self:provider.stage}.LOG_LEVEL}

--- a/serverless.yml
+++ b/serverless.yml
@@ -27,9 +27,10 @@ custom:
 functions:
 
   CommitteeSync:
+    description: Polls OpenFEC API (once) for committees that have filed recently and sends the IDs to SQS
     handler: src/CommitteSync.committeSync
-    timeout: 30
     reservedConcurrency: 2
+    timeout: 30
     environment:
       API_KEY: ${self:custom.${self:provider.stage}.API_KEY}
       LOG_LEVEL: ${self:custom.${self:provider.stage}.LOG_LEVEL}
@@ -38,7 +39,9 @@ functions:
       - schedule: cron(0 0,8,16 * * ? *)
 
   CommitteeLoader:
+    description: Recieves committee Ids from SQS, queries api for committee info, updates DB
     handler: src/CommitteLoader.committeLoader
+    reservedConcurrency: 2
     timeout: 30
     environment:
       API_KEY: ${self:custom.${self:provider.stage}.API_KEY}
@@ -48,6 +51,7 @@ functions:
       - sqs: "${self:custom.${self:provider.stage}.SQS_QUEUE_ARN}"
 
   FilingSync:
+    description: Scrapes FEC RSS feed for recent filings, pushes the new filings to SNS and SQS
     handler: src/FilingSync.lambdaHandler
     timeout: 180
     environment:
@@ -57,9 +61,10 @@ functions:
       - schedule: cron(0 0,8,16 * * ? *)
 
   FinancialSummaryLoader:
+    description: Takes new filings from SQS, queries api, writes to DB
     handler: src/FinancialSummaryLoader.lambdaHandler
     reservedConcurrency: 2
-    timeout: 60
+    timeout: 90
     environment:
       API_KEY: ${self:custom.${self:provider.stage}.API_KEY}
       LOG_LEVEL: ${self:custom.${self:provider.stage}.LOG_LEVEL}

--- a/serverless.yml
+++ b/serverless.yml
@@ -29,7 +29,7 @@ functions:
   CommitteeSync:
     description: Polls OpenFEC API (once) for committees that have filed recently and sends the IDs to SQS
     handler: src/CommitteSync.committeSync
-    reservedConcurrency: 2
+    reservedConcurrency: 1
     timeout: 30
     environment:
       API_KEY: ${self:custom.${self:provider.stage}.API_KEY}
@@ -41,7 +41,7 @@ functions:
   CommitteeLoader:
     description: Recieves committee Ids from SQS, queries api for committee info, updates DB
     handler: src/CommitteLoader.committeLoader
-    reservedConcurrency: 2
+    reservedConcurrency: 1
     timeout: 30
     environment:
       API_KEY: ${self:custom.${self:provider.stage}.API_KEY}
@@ -53,6 +53,7 @@ functions:
   FilingSync:
     description: Scrapes FEC RSS feed for recent filings, pushes the new filings to SNS and SQS
     handler: src/FilingSync.lambdaHandler
+    reservedConcurrency: 1
     timeout: 180
     environment:
       LOG_LEVEL: ${self:custom.${self:provider.stage}.LOG_LEVEL}
@@ -63,7 +64,7 @@ functions:
   FinancialSummaryLoader:
     description: Takes new filings from SQS, queries api, writes to DB
     handler: src/FinancialSummaryLoader.lambdaHandler
-    reservedConcurrency: 2
+    reservedConcurrency: 1
     timeout: 90
     environment:
       API_KEY: ${self:custom.${self:provider.stage}.API_KEY}

--- a/serverless.yml
+++ b/serverless.yml
@@ -77,17 +77,19 @@ package:
   exclude:
     - .env
     - .venv
-    - .vscode
+    - .vscode/**
     - .git/**
     - .gitignore
-    - .pytest_cache
+    - .pytest_cache/**
+    - bin/**
     - node_modules/**
     - package.json
     - package-lock.json
     - prerequisite-cloudformation-resources.yml
     - README.md
     - requirements.txt
-    - tmp
+    - sql/**
+    - tmp/**
 
 # plugin to package dependencies
 plugins:

--- a/src/CommitteLoader.py
+++ b/src/CommitteLoader.py
@@ -71,6 +71,7 @@ def committeLoader(event: dict, context: object) -> bool:
     start_time = time()
     time_to_end = start_time + 60 * 10
     logger.info(f'Running committeeLoader from now until {time_to_end}')
+    logger.debug(event)
 
     while time() < time_to_end:
         message = pull_message_from_sqs()

--- a/src/CommitteLoader.py
+++ b/src/CommitteLoader.py
@@ -19,7 +19,7 @@ from src import logger
 from src.OpenFec import OpenFec
 from src.secrets import get_param_value_by_name
 from src.serialization import serialize_dates
-from src.sqs import pull_message_from_sqs
+from src.sqs import delete_message_from_sqs, parse_message
 
 
 # SSM VARS
@@ -68,16 +68,16 @@ def committeLoader(event: dict, context: object) -> bool:
         json:
     """
 
-    start_time = time()
-    time_to_end = start_time + 60 * 10
-    logger.info(f'Running committeeLoader from now until {time_to_end}')
+    logger.info(f'running {__file__}')
     logger.debug(event)
 
-    while time() < time_to_end:
-        message = pull_message_from_sqs()
-        if not message:
-            return
-        committee_id = message.body
+    messages = event['Records']
+
+    for message in messages:
+
+        message_parsed = parse_message(message)
+        committee_id = message_parsed
+
         committee_data = get_committee_data(committee_id)
 
         if not committee_data:
@@ -85,10 +85,7 @@ def committeLoader(event: dict, context: object) -> bool:
             return False
 
         write_committee_data(committee_data[0])
-        message.delete()
 
-    if time() > time_to_end:
-        minutes_ran = (time() - start_time) / 60
-        logger.warn(f'committeeLoader ended late at {minutes_ran} ')
+        delete_message_from_sqs(message)
 
     return True

--- a/src/FilingSync.py
+++ b/src/FilingSync.py
@@ -140,6 +140,7 @@ def send_message_to_sns(msg: str) -> Dict[str, str]:
 
     return sns_response
 
+
 # handler for aws lambda
 def lambdaHandler(event: dict, context: object):
     """lambdaHandler
@@ -152,7 +153,9 @@ def lambdaHandler(event: dict, context: object):
     eFilingRSSFeed = EFilingRSSFeed()
     items = eFilingRSSFeed.get_items_from_rss_feeds_of_interest()
     sns_replies = []
+
     for item in items:
         ret = send_message_to_sns(item)
         sns_replies.append(ret)
+
     return sns_replies

--- a/src/FinancialSummaryLoader.py
+++ b/src/FinancialSummaryLoader.py
@@ -18,48 +18,13 @@ from src import JSONType, logger, schema
 from src.database import Database
 from src.OpenFec import OpenFec
 from src.secrets import get_param_value_by_name
+from src.sqs import delete_message_from_sqs, parse_message
 
 
 # SSM VARS
 API_KEY = get_param_value_by_name(os.environ['API_KEY'])
 
 # BUSYNESS LOGIC
-
-def parse_events(event: JSONType) -> List[Dict[str, Any]]:
-    """takes the raw event from AWS Lambda and parses into a list of messages
-
-    Args:
-        event (JSONType): List of SQS Message events
-            see https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
-
-    Returns:
-        List[Dict[str, Any]]: List of message bodies
-    """
-
-    message_body_list = []
-    records = event['Records']
-    for record in records:
-        my_body = record['body']
-        json_body = json.loads(my_body)
-        message_body_list.append(json_body)
-
-    return message_body_list
-
-
-def parse_message(message: JSONType) -> Dict[str, str]:
-    """parse string from sqs - it's kind of jsonish
-
-    Args:
-        message (JSON): almost json
-
-    Returns:
-        Dict[str, str]: python dictionary
-    """
-
-    body_content = json.loads(message['Message'].replace("'", '"'))
-
-    return body_content
-
 
 def get_filings(filters: Dict[str, str]) -> Dict[str, Any]:
     """pulls filings from openfec api
@@ -214,8 +179,9 @@ def lambdaHandler(event:dict, context: object) -> bool:
     """
 
     logger.debug(f'running {__file__}')
+    logger.debug(event)
 
-    messages = parse_events(event)
+    messages = event['Records']
 
     for message in messages:
 
@@ -231,5 +197,7 @@ def lambdaHandler(event:dict, context: object) -> bool:
         # filing is list of lists, flatten it
         totals_flat = [item for sublist in totals for item in sublist]
         upsert_committee_totals(totals_flat)
+
+        delete_message_from_sqs(message)
 
     return True

--- a/src/FinancialSummaryLoader.py
+++ b/src/FinancialSummaryLoader.py
@@ -213,11 +213,7 @@ def lambdaHandler(event:dict, context: object) -> bool:
         bool: Did this go well?
     """
 
-    start_time = time()
-    minutes_to_run = 10
-    time_to_end = start_time + 60 * minutes_to_run
-    logger.debug(f'running {__file__} for {minutes_to_run}, from now until {asctime(gmtime(time_to_end))}')
-    logger.debug(event)
+    logger.debug(f'running {__file__}')
 
     messages = parse_events(event)
 
@@ -235,7 +231,5 @@ def lambdaHandler(event:dict, context: object) -> bool:
         # filing is list of lists, flatten it
         totals_flat = [item for sublist in totals for item in sublist]
         upsert_committee_totals(totals_flat)
-
-
 
     return True

--- a/src/sqs.py
+++ b/src/sqs.py
@@ -7,16 +7,16 @@ sqs:
 import boto3
 import os
 import json
-from src import logger
+from src import logger, JSONType
 from time import time
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 
 sqs = boto3.resource('sqs')
 SQS_QUEUE_NAME = os.environ['SQS_QUEUE_NAME']
 logger.debug(f'using queue: {SQS_QUEUE_NAME}')
-# SQS_QUEUE_NAME = os.getenv('SQS_QUEUE_NAME', '')
 queue = sqs.get_queue_by_name(QueueName=SQS_QUEUE_NAME)
+
 
 def pull_message_from_sqs() -> Dict[str, Any]:
     """pulls a committee id from SQS
@@ -31,6 +31,57 @@ def pull_message_from_sqs() -> Dict[str, Any]:
     while time() < time_to_end:
         message = queue.receive_messages(MaxNumberOfMessages=1)
         if message:
+
             return message[0]
+
     logger.info('No messages received, exiting')
+
     return {}
+
+
+def delete_message_from_sqs(message: JSONType) -> bool:
+    """deletes a message from SQS
+
+    Args:
+        message (JSONType): the SQS Message object
+
+    Returns:
+        bool: if deleted
+    """
+
+    receipt_handle = message['receiptHandle']
+    msg_id = message['messageId']
+
+    response = queue.delete_messages(
+        Entries=[{
+            'Id': msg_id,
+            'ReceiptHandle': receipt_handle
+        }])
+
+    if len(response['Successful']) > 0:
+        return True
+
+    return False
+
+
+def parse_message(message: JSONType) -> Dict[str, str]:
+    """parse string from sqs - it's kind of jsonish
+        those coming from SNS -> SQS are JSON in a 'Message' object
+        those coming from -> SQS are a string
+
+    Args:
+        message (JSON): almost json
+
+    Returns:
+        Dict[str, str]: python dictionary
+    """
+
+    my_body = message['body']
+    json_body = json.loads(my_body)
+
+    if type(json_body) == dict:
+        body_content = json.loads(json_body['Message'].replace("'", '"'))
+
+        return body_content
+
+    return json_body.replace("'", '')


### PR DESCRIPTION
Before I was pulling from SQS but the event trigger passes a batch of messages in through the `event` object. I'm using those rather than polling SQS to help prevent race conditions where the same messages get processed multiple times. Also some minor clean up stuff. 